### PR TITLE
Return didDisappear stream in NavSource.didDisappear instead of didAppear

### DIFF
--- a/src/NavSource.ts
+++ b/src/NavSource.ts
@@ -41,7 +41,7 @@ export class NavSource {
   }
 
   public didDisappear() {
-    return this._didAppear;
+    return this._didDisappear;
   }
 
   public globalDidDisappear(componentName?: string): Stream<DisappearEvent> {


### PR DESCRIPTION
This fixes an issue where components fire appear and disappear immediately after appearing, and nothing when disappearing.